### PR TITLE
Verifying built file count on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,10 @@ jobs:
             --detect.project.name="Qlik-Sense-Tabs"
       - run:
           name: Build
-          command: npm run build:zip
+          command: |
+            npm run build:zip
+            sudo chmod +x ./.circleci/verify-files.sh
+            ./.circleci/verify-files.sh
       - persist_to_workspace:
           root: ~/qlik-tabbed-container
           paths:

--- a/.circleci/verify-files.sh
+++ b/.circleci/verify-files.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# The build script has a known race-condition that sometimes causes it to not include all files
+# in the built zip. This script verifies the that the zip contains the correct number of files.
+
+set -o errexit
+
+echo "Verifying built file count"
+
+while read line; do
+    if [[ $line =~ ^\"name\": ]]; then
+        name=${line#*: \"}
+        name=${name%\"*}
+    elif [[ $line =~ ^\"version\": ]]; then
+        version=${line#*: \"}
+        version=${version%\"*}
+    fi
+done < package.json
+
+expected_file_count=$(($(find dist -type f | wc -l)-1))
+zip_file_count=$(zipinfo dist/${name}_${version}.zip | grep ^- | wc -l)
+
+if [ "${expected_file_count}" -ne "${zip_file_count}" ]; then
+    # File count is incorrect
+    echo "Expected file count ${expected_file_count}, but was ${zip_file_count}"
+    exit 1
+fi
+echo "File count OK"
+exit 0


### PR DESCRIPTION
-gulp sometimes fails to include all files when zipping.
CircleCI will now help us detect when that happens.